### PR TITLE
Expose more toast atmosphere parameters.

### DIFF
--- a/tolteca/simu/toltec/models.py
+++ b/tolteca/simu/toltec/models.py
@@ -1249,6 +1249,12 @@ class ToltecPowerLoadingModel(PowerLoadingModel):
 @dataclass
 class ToastAtmConfig(object):
     """The config class for TOAST atm model."""
+    median_weather: bool = field(
+        default=True,
+        metadata={
+            'description': 'use median weather information'
+        }
+    )
     lmin_center: u.Quantity = field(
         default=0.01 << u.meter,
         metadata={
@@ -1305,10 +1311,58 @@ class ToastAtmConfig(object):
             'schema': PhysicalTypeSchema('length')
             }
         )
+    rmin: u.Quantity = field(
+        default=0 << u.meter,
+        metadata={
+            'description': 'The rmin value'
+        }
+    )
+    rmax: u.Quantity = field(
+        default=100 << u.meter,
+        metadata={
+            'description': 'The rmin value'
+        }
+    )
+    scale: np.float64 = field(
+        default=10.0,
+        metadata = {
+            'description': 'scale value'
+        }
+    )
+    xstep: u.Quantity = field(
+        default=5 << u.meter,
+        metadata={
+            'description': 'The xstep value'
+        }
+    )
+    ystep: u.Quantity = field(
+        default=5 << u.meter,
+        metadata={
+            'description': 'The ystep value'
+        }
+    )
+    zstep: u.Quantity = field(
+        default=5 << u.meter,
+        metadata={
+            'description': 'The zstep value'
+        }
+    )
     nelem_sim_max: np.int = field(
         default=20000,
         metadata={
             'description': 'The nelem_sim_max value',
+            }
+        )
+    key1: np.int = field(
+        default=0,
+        metadata={
+            'description': 'key1 randomization',
+            }
+        )
+    key2: np.int = field(
+        default=0,
+        metadata={
+            'description': 'key2 randomization',
             }
         )
 

--- a/tolteca/simu/toltec/models.py
+++ b/tolteca/simu/toltec/models.py
@@ -1311,6 +1311,24 @@ class ToastAtmConfig(object):
             'schema': PhysicalTypeSchema('length')
             }
         )
+    w_sigma: u.Quantity = field(
+        default= 0 << (u.km / u.second),
+        metadata = {
+            'description': 'w_sigma value: (w_center is set by the weather)'
+        }
+    )
+    wdir_sigma: u.Quantity = field(
+        default= 0 << u.radian,
+        metadata = {
+            'description': 'wdir_sigma value: (wdir_center is set by the weather)'
+        }
+    )
+    T0_sigma: u.Quantity = field(
+        default=10 * u.Kelvin, 
+        metadata = {
+            'description': 'T0_sigma value: (T0_center is set by the weather)'
+        }
+    )
     rmin: u.Quantity = field(
         default=0 << u.meter,
         metadata={

--- a/tolteca/simu/toltec/toast_atm.py
+++ b/tolteca/simu/toltec/toast_atm.py
@@ -130,6 +130,7 @@ class ToastAtmosphereSimulation(object):
 
     def _generate_toast_atm_slabs(
         self, 
+        median_weather,
         t0, 
         tmin, 
         tmax, 
@@ -157,16 +158,16 @@ class ToastAtmosphereSimulation(object):
         # toast_env.set_log_level('DEBUG')
 
         # Starting slab parameters (thank you Ted)
-        rmin  =  0 * u.meter
-        rmax  =  100 * u.meter
-        scale =  10.0
-        xstep =  5 * u.meter
-        ystep =  5 * u.meter
-        zstep =  5 * u.meter
+        # rmin  =  0 * u.meter
+        # rmax  =  100 * u.meter
+        # scale =  10.0
+        # xstep =  5 * u.meter
+        # ystep =  5 * u.meter
+        # zstep =  5 * u.meter
 
         # RNG state
-        key1     = 0
-        key2     = 0
+        # key1     = 0
+        # key2     = 0
         counter1 = 0
         counter2 = 0
 

--- a/tolteca/simu/toltec/toast_atm.py
+++ b/tolteca/simu/toltec/toast_atm.py
@@ -145,6 +145,9 @@ class ToastAtmosphereSimulation(object):
         z0_sigma, 
         zatm, 
         zmax,
+        w_sigma,
+        wdir_sigma,
+        T0_sigma,
         nelem_sim_max,
         median_weather,
         rmin,
@@ -210,13 +213,13 @@ class ToastAtmosphereSimulation(object):
                 lmax_center=lmax_center,
                 lmax_sigma =lmax_sigma,  
                 w_center=w_center,
-                w_sigma=0 * (u.km / u.second),
+                w_sigma=w_sigma, #0 * (u.km / u.second), # w_sigma
                 wdir_center=wdir_center,
-                wdir_sigma=0 * u.radian,
+                wdir_sigma=wdir_sigma, #0 * u.radian, #
                 z0_center=z0_center,  #,2000 * u.meter,
                 z0_sigma=z0_sigma,  #0 * u.meter,
                 T0_center=self.T0_center,
-                T0_sigma=10 * u.Kelvin,
+                T0_sigma=T0_sigma, #10 * u.Kelvin, # 
                 zatm=zatm, 
                 zmax=zmax, 
                 xstep=xstep,

--- a/tolteca/simu/toltec/toast_atm.py
+++ b/tolteca/simu/toltec/toast_atm.py
@@ -130,7 +130,6 @@ class ToastAtmosphereSimulation(object):
 
     def _generate_toast_atm_slabs(
         self, 
-        median_weather,
         t0, 
         tmin, 
         tmax, 
@@ -147,6 +146,15 @@ class ToastAtmosphereSimulation(object):
         zatm, 
         zmax,
         nelem_sim_max,
+        median_weather,
+        rmin,
+        rmax,
+        scale,
+        xstep,
+        ystep,
+        zstep,
+        key1,
+        key2,
         mpi_comm=None
     ):
         """Creates the atmosphere models using multiple slabs
@@ -174,7 +182,7 @@ class ToastAtmosphereSimulation(object):
         # obtain the weather information
         self.sim_weather = toast.weather.SimWeather(
             time = t0.to_datetime(timezone=datetime.timezone.utc),
-            name="LMT", median_weather=True
+            name="LMT", median_weather=median_weather
         )
         self.T0_center   = self.sim_weather.air_temperature
         self.wx          = self.sim_weather.west_wind


### PR DESCRIPTION
Make all the toast parameters accessible in configuration. If none is provided, it defaults to the defaults that we've been using.

In particular, can force a different realization of the atmosphere (for otherwise identical observing parameters) by modifying the `key1` and/or `key2` values.